### PR TITLE
fix(algorithm-env): use full neutral+negative+positive pool for diverse recs (#1711)

### DIFF
--- a/backend/simulation/env/algorithm_env.py
+++ b/backend/simulation/env/algorithm_env.py
@@ -219,12 +219,16 @@ class AlgorithmEnv(EnvBase):
             else:
                 pool = self._content_pool["neutral"]
         else:
-            # 低概率推荐多元内容
-            pool = self._content_pool["neutral"] + self._rng.choice([
-                self._content_pool["negative"],
-                self._content_pool["positive"]
-            ])
-        
+            # 低概率推荐多元内容：合并全部三类内容，而不是
+            # neutral + choice([negative, positive]) —— 原逻辑只保留
+            # negative / positive 其中一类，导致分布偏向某一侧，与
+            # "多元" 的语义相悖 (issue #1711)。
+            pool = (
+                self._content_pool["neutral"]
+                + self._content_pool["negative"]
+                + self._content_pool["positive"]
+            )
+
         return self._rng.choice(pool)
     
     def _record_exposure(self, agent_id: int, content: str, alignment: float):


### PR DESCRIPTION
## Summary

The low-cocoon branch of \`_generate_recommendation\` built its recommendation pool as:

\`\`\`python
pool = self._content_pool[\"neutral\"] + self._rng.choice([
    self._content_pool[\"negative\"],
    self._content_pool[\"positive\"],
])
\`\`\`

\`choice()\` evaluates once per call and keeps only one of \`negative\`/\`positive\`, so the pool becomes \`3 neutral + 5 one-sided\`. The "diverse" branch therefore delivers a 62.5% bias onto whichever side \`choice()\` happened to pick — the opposite of what the \`多元内容\` comment promises.

## Fix

Merge all three content lists so the diverse branch samples evenly across \`neutral\`, \`negative\`, and \`positive\`:

\`\`\`python
pool = (
    self._content_pool[\"neutral\"]
    + self._content_pool[\"negative\"]
    + self._content_pool[\"positive\"]
)
\`\`\`

Fixes #1711

## Test plan

- [x] \`python3 -c 'import ast; ast.parse(...)'\` — syntax clean
- [x] Trace: 3 + 5 + 5 = 13 items, \`self._rng.choice(pool)\` samples uniformly so neutral/negative/positive each get ~23%/38%/38% — the imbalance is now *only* the underlying list sizes, not the branch logic