### PR TITLE
Fix #2201: Replace deprecated np.random.RandomState

### DIFF
--- a/backend/simulation/dual_network.py
+++ b/backend/simulation/dual_network.py
@@ -32,7 +32,7 @@ class DualLayerNetwork:
         self.intra_community_prob = intra_community_prob
         self.inter_community_prob = inter_community_prob
         self.seed = seed
-        self._rng = np.random.RandomState(seed)
+        self._rng = np.random.default_rng(seed)
 
         # 构建双层网络
         self.public_graph = self._build_public_network()


### PR DESCRIPTION
## Summary
- 替换弃用的 `np.random.RandomState` 为 `np.random.default_rng`
- 符合 NumPy 1.17+ 推荐的 Generator API
- 避免弃用警告和未来兼容性问题

## Changes
- `backend/simulation/dual_network.py:35`: `np.random.RandomState(seed)` → `np.random.default_rng(seed)`

## Test plan
- [x] 现有单元测试通过

Fixes #2201

🤖 Generated with [Claude Code](https://claude.com/claude-code)