### PR TITLE
Fix #2197: Add defensive division in compute_social_validation

### DIFF
--- a/backend/simulation/message/group_chat.py
+++ b/backend/simulation/message/group_chat.py
@@ -229,10 +229,11 @@ class GroupChat:
         
         if not group_opinions:
             return {"validation": 0.5, "agreement_ratio": 0.0}
-        
-        # 计算认同比例
+
+        # 计算认同比例（防御性除法，避免 ZeroDivisionError）
+        opinion_count = len(group_opinions)
         agreeing = sum(1 for op in group_opinions if (op > 0) == (agent_opinion > 0))
-        agreement_ratio = agreeing / len(group_opinions)
+        agreement_ratio = agreeing / opinion_count if opinion_count > 0 else 0.0
         
         # 社会验证强度
         validation = (agreement_ratio * self.validation_weight_agreement +


### PR DESCRIPTION
## Summary
- 添加防御性除法，避免潜在的 ZeroDivisionError
- 使用显式 `opinion_count` 变量替代内联 `len()`
- 增强代码健壮性，即使未来重构移除前置检查也不会出错

## Changes
- `backend/simulation/message/group_chat.py`: 添加防御性除法

## Test plan
- [x] 现有单元测试通过 (82 passed)

Fixes #2197

🤖 Generated with [Claude Code](https://claude.com/claude-code)