### PR TITLE
Fix #2199: Add engine cleanup in state.reset()

### DIFF
--- a/backend/simulation/env/base.py
+++ b/backend/simulation/env/base.py
@@ -1,0 +1,152 @@
+"""
+EnvBase - 环境模块基类
+
+定义环境工具的标准接口:
+- @tool 装饰器: 标注可调用方法
+- EnvBase 抽象类: 定义环境模块接口
+"""
+from abc import ABC, abstractmethod
+from typing import Dict, List, Any, Optional, Callable
+from dataclasses import dataclass
+from enum import Enum
+import asyncio
+import functools
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class ToolKind(str, Enum):
+    """工具类型"""
+    OBSERVE = "observe"      # 感知类（只读）
+    STATISTICS = "statistics"  # 统计类（只读）
+    INTERACT = "interact"    # 交互类（可写）
+
+
+@dataclass
+class EnvTool:
+    """环境工具描述"""
+    name: str
+    description: str
+    kind: ToolKind
+    readonly: bool
+    parameters: Dict[str, Any]
+    func: Callable
+
+
+def tool(readonly: bool = True, kind: str = "observe"):
+    """
+    环境工具装饰器
+    
+    标注方法为可被 Agent 调用的环境工具
+    
+    Args:
+        readonly: 是否只读（不修改环境状态）
+        kind: 工具类型 (observe/statistics/interact)
+    
+    Example:
+        @tool(readonly=True, kind="observe")
+        async def get_recommendation(self, agent_id: int) -> str:
+            return "推荐内容..."
+    """
+    def decorator(func):
+        @functools.wraps(func)
+        async def wrapper(*args, **kwargs):
+            if asyncio.iscoroutinefunction(func):
+                return await func(*args, **kwargs)
+            return func(*args, **kwargs)
+
+        # 添加元数据
+        wrapper._is_tool = True
+        wrapper._readonly = readonly
+        wrapper._kind = ToolKind(kind)
+
+        return wrapper
+    return decorator
+
+
+class EnvBase(ABC):
+    """
+    环境模块抽象基类
+    
+    所有环境模块必须实现:
+    - name: 环境名称
+    - get_tools(): 返回可调用工具列表
+    - reset(): 重置环境状态
+    
+    子类通过 @tool 装饰器标注可调用方法
+    """
+    
+    def __init__(self):
+        self._tools: Dict[str, EnvTool] = {}
+        self._scan_tools()
+    
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """环境名称"""
+        pass
+    
+    def _scan_tools(self):
+        """扫描并注册带 @tool 装饰器的方法"""
+        for attr_name in dir(self):
+            attr = getattr(self, attr_name)
+            if hasattr(attr, '_is_tool'):
+                # 收集参数信息
+                import inspect
+                sig = inspect.signature(attr)
+                params = {
+                    name: param.annotation.__name__ if hasattr(param.annotation, '__name__') else str(param.annotation)
+                    for name, param in sig.parameters.items()
+                    if name != 'self'
+                }
+                
+                self._tools[attr_name] = EnvTool(
+                    name=f"{self.name}_{attr_name}",
+                    description=attr.__doc__ or "",
+                    kind=attr._kind,
+                    readonly=attr._readonly,
+                    parameters=params,
+                    func=attr
+                )
+    
+    def get_tools(self) -> List[EnvTool]:
+        """获取所有可用工具"""
+        return list(self._tools.values())
+    
+    def get_tool(self, name: str) -> Optional[EnvTool]:
+        """获取指定工具"""
+        return self._tools.get(name)
+    
+    async def call_tool(self, name: str, *args, **kwargs) -> Any:
+        """调用工具"""
+        tool = self._tools.get(name)
+        if tool is None:
+            raise ValueError(f"Tool {name} not found in {self.name}")
+        
+        return await tool.func(*args, **kwargs)
+    
+    @abstractmethod
+    async def reset(self):
+        """重置环境状态"""
+        pass
+    
+    @abstractmethod
+    async def get_state(self) -> Dict[str, Any]:
+        """获取环境状态"""
+        pass
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """导出为字典"""
+        return {
+            "name": self.name,
+            "tools": [
+                {
+                    "name": t.name,
+                    "description": t.description,
+                    "kind": t.kind.value,
+                    "readonly": t.readonly
+                }
+                for t in self._tools.values()
+            ]
+        }

--- a/backend/state.py
+++ b/backend/state.py
@@ -103,7 +103,15 @@ class GlobalState:
     def reset(self):
         """重置所有状态"""
         with self._lock:
-            self._engine = None
+            # 清理引擎资源（如果存在 cleanup 方法）
+            if self._engine is not None:
+                cleanup_method = getattr(self._engine, 'cleanup', None)
+                if cleanup_method is not None:
+                    try:
+                        cleanup_method()
+                    except Exception:
+                        pass  # 忽略清理错误，确保状态重置继续
+                self._engine = None
             self._pending_knowledge_graph = None
             self._pending_event_content = None
             self._pending_event_source = None


### PR DESCRIPTION
## Summary
- 在重置状态时调用引擎的 cleanup 方法
- 防止因未清理资源导致的内存泄漏
- 使用 try/except 包装确保重置继续

## Changes
- `backend/state.py`: 添加引擎 cleanup 调用
- `backend/simulation/env/base.py`: 恢复丢失的文件

## Test plan
- [x] 现有单元测试通过 (82 passed)

Fixes #2199

🤖 Generated with [Claude Code](https://claude.com/claude-code)