### PR TITLE
Fix #2222: Extend UUID truncation from 8 to 12 characters

### DIFF
--- a/backend/simulation/message/models.py
+++ b/backend/simulation/message/models.py
@@ -37,8 +37,8 @@ class Message(BaseModel):
     Agent 间通信的基本单位
     """
     
-    # 基本信息
-    id: str = Field(default_factory=lambda: str(uuid.uuid4())[:8])
+    # 基本信息 (issue #2222: 使用12字符UUID降低碰撞风险)
+    id: str = Field(default_factory=lambda: str(uuid.uuid4())[:12])
     message_type: MessageType = MessageType.P2P
     
     # 发送接收


### PR DESCRIPTION
## Summary
- Change UUID truncation from 8 to 12 hex characters
- 8 chars = 32 bits (~4 billion possible)
- 12 chars = 48 bits (~281 trillion possible)

Fixes #2222

🤖 Generated with [Claude Code](https://claude.com/claude-code)