### PR TITLE
Fix #2231: Move math import to module top level

### DIFF
--- a/backend/simulation/message/p2g.py
+++ b/backend/simulation/message/p2g.py
@@ -8,6 +8,7 @@ P2G Broadcaster - Agent 广播通信
 """
 from typing import Dict, List, Optional
 import random
+import math
 import logging
 
 from .models import Message, MessageType, MessageStatus
@@ -133,7 +134,6 @@ class P2GBroadcaster:
         # 影响力随距离衰减 (issue #361)
         # 使用指数衰减: decay_factor = exp(-decay_rate * (distance - 1))
         if distance > 1:
-            import math
             decay_factor = math.exp(-self._decay_rate * (distance - 1))
             effective_prob = base_prob * decay_factor
         else:


### PR DESCRIPTION
## Summary
- Remove inline import math from conditional block
- Move to module top level following Python conventions

Fixes #2231

🤖 Generated with [Claude Code](https://claude.com/claude-code)