### PR TITLE
Fix #2244: 使用实例级RNG替代全局np.random

### DIFF
--- a/backend/simulation/prediction.py
+++ b/backend/simulation/prediction.py
@@ -65,6 +65,9 @@ class PredictionConfig:
     # 历史数据最小长度（少于此时不做预测）
     min_history_length: int = field(default_factory=lambda: _get_env_int("PREDICTION_MIN_HISTORY", 3))
 
+    # 随机种子（用于可复现性，issue #2244）
+    seed: int = field(default_factory=lambda: _get_env_int("PREDICTION_SEED", 42))
+
 
 @dataclass
 class PredictionInterval:
@@ -96,6 +99,9 @@ class MonteCarloPredictor:
 
     def __init__(self, config: PredictionConfig = None):
         self.config = config or PredictionConfig()
+
+        # 实例级随机生成器 (issue #2244: 确保可复现性)
+        self._rng = np.random.default_rng(self.config.seed)
 
         # 存储历史数据
         self.history: List[Dict] = []
@@ -193,8 +199,8 @@ class MonteCarloPredictor:
             # 随机游走模型
             value = current_value
             for _ in range(self.config.forecast_steps):
-                # 趋势 + 随机波动
-                noise = np.random.normal(0, volatility)
+                # 趋势 + 随机波动 (issue #2244: 使用实例级RNG)
+                noise = self._rng.normal(0, volatility)
                 change = trend + noise
                 value = np.clip(value + change, 0, 1)
             final_values.append(value)


### PR DESCRIPTION
## Summary
- 在PredictionConfig添加seed参数支持环境变量覆盖
- 在MonteCarloPredictor添加实例级_rng属性
- 将蒙特卡洛模拟中的`np.random.normal`改为`self._rng.normal`

## Why
全局numpy随机数生成器会受其他代码影响，破坏可复现性。使用实例级RNG确保每次运行结果可复现。

## Test plan
- [x] 运行`pytest tests/unit/` - 82个测试全部通过

Fixes #2244