### PR TITLE
Fix #2249: 使用正常的threading导入替代__import__

### DIFF
--- a/backend/llm/client.py
+++ b/backend/llm/client.py
@@ -7,6 +7,7 @@ import aiohttp
 import json
 import os
 import re
+import threading  # issue #2249: 使用正常导入
 from typing import Optional, Dict, Any, List
 from dataclasses import dataclass, field
 import logging
@@ -434,7 +435,7 @@ class LLMClient:
 
 # 全局客户端实例
 _llm_client: Optional[LLMClient] = None
-_llm_client_lock = __import__('threading').Lock()
+_llm_client_lock = threading.Lock()  # issue #2249: 使用正常导入
 
 
 def get_llm_client(config: Optional[LLMConfig] = None) -> LLMClient:


### PR DESCRIPTION
## Summary
- 在文件顶部添加`import threading`
- 将`__import__('threading').Lock()`改为`threading.Lock()`

## Why
使用`__import__('threading')`是不寻常的写法，降低了代码可读性，且IDE和静态分析工具难以正确解析。正常的导入语句更符合Python惯例。

## Test plan
- [x] 运行`pytest tests/unit/` - 82个测试全部通过

Fixes #2249