### PR TITLE
Fix #2402: Intervention._next_id class variable state leak

### DIFF
--- a/backend/simulation/env/truth_env.py
+++ b/backend/simulation/env/truth_env.py
@@ -15,6 +15,11 @@ class Intervention:
 
     _next_id: int = 0
 
+    @classmethod
+    def reset_id_counter(cls) -> None:
+        """Reset the ID counter for new simulation runs."""
+        cls._next_id = 0
+
     def __init__(
         self,
         step: int,
@@ -178,6 +183,7 @@ class TruthEnv(EnvBase):
                 )
 
     async def reset(self):
+        Intervention.reset_id_counter()
         self._interventions.clear()
         self._published.clear()
         self._exposure_tracking.clear()


### PR DESCRIPTION
## Summary
- Add `reset_id_counter()` classmethod to `Intervention` class in `truth_env.py`
- Call `reset_id_counter()` in `TruthEnv.reset()` to clean state between simulation runs
- Prevents ID pollution across multiple test runs and simulations

## Problem
The class variable `_next_id` was never reset between simulations, causing:
- ID pollution across test runs
- IDs continuously incrementing instead of starting fresh

## Solution
```python
@classmethod
def reset_id_counter(cls) -> None:
    """Reset the ID counter for new simulation runs."""
    cls._next_id = 0
```

Called in `TruthEnv.reset()` to ensure clean state.

## Test Plan
- Existing tests pass
- New simulation runs start with ID=1

Fixes #2402

🤖 Generated with [Claude Code](https://claude.com/claude-code)