### PR TITLE
Fix #2386: Extract duplicate reset code to helper function

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,8 @@ project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
 
-@pytest.fixture
-def reset_global_state():
-    """Reset mutable global state between tests."""
+def _reset_global_state_impl():
+    """Helper function to reset mutable global state."""
     from backend import state
     import backend.llm.client
     from backend.simulation.graph_parser_agent import reset_graph_parser
@@ -34,19 +33,14 @@ def reset_global_state():
 
     try:
         from backend.simulation.env.truth_env import Intervention
-        Intervention._next_id = 0
+        Intervention.reset_id_counter()
     except ImportError:
         pass
 
+
+@pytest.fixture
+def reset_global_state():
+    """Reset mutable global state between tests."""
+    _reset_global_state_impl()
     yield
-
-    clear_agent_snapshots()
-    state.reset_state()
-    backend.llm.client._llm_client = None
-    reset_graph_parser()
-    reset_risk_engine()
-
-    PersonAgent.opinion_max_change_factor = 0.3
-    PersonAgent.social_influence_coeff = 0.3
-    PersonAgent.silence_fear_threshold = 0.6
-    PersonAgent.silence_delta_threshold = 0.1
+    _reset_global_state_impl()


### PR DESCRIPTION
## Summary
- Extract common reset logic into `_reset_global_state_impl()` helper function
- Call helper from both setup and teardown in `reset_global_state` fixture
- Update Intervention reset to use `reset_id_counter()` method
- Follows DRY principle, reduces maintenance burden

## Problem
The `reset_global_state` fixture had duplicate code between setup and teardown:
- Lines 24-39 (setup) duplicated Lines 43-52 (teardown)
- Modification required syncing two places

## Solution
```python
def _reset_global_state_impl():
    """Helper function to reset mutable global state."""
    # ... reset logic ...

@pytest.fixture
def reset_global_state():
    _reset_global_state_impl()
    yield
    _reset_global_state_impl()
```

## Test Plan
- All existing tests pass (fixture behavior unchanged)

Fixes #2386

🤖 Generated with [Claude Code](https://claude.com/claude-code)