### PR TITLE
Fix #2374: Replace hardcoded Chinese action strings with English

### DIFF
--- a/backend/simulation/agent/base.py
+++ b/backend/simulation/agent/base.py
@@ -290,7 +290,7 @@ class MathModelAgent(AgentBase):
             "new_opinion": new_opinion,
             "delta": delta,
             "is_silent": is_silent,
-            "action": "沉默" if is_silent else "观望"
+            "action": "silence" if is_silent else "observe"
         }
     
     async def act(self, decision: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- Replace "沉默" with "silence"
- Replace "观望" with "observe"
- Enables i18n for API responses

## Problem
The `MathModelAgent.decide()` method returned hardcoded Chinese action strings:
- "沉默" (silence)
- "观望" (observe)

This prevented internationalization of API responses.

## Solution
Use English action constants that can be translated on the frontend:
```python
"action": "silence" if is_silent else "observe"
```

## Test Plan
- Existing tests pass (action value checked, not hardcoded string)

Fixes #2374

🤖 Generated with [Claude Code](https://claude.com/claude-code)