### PR TITLE
Fix #2379: Replace hardcoded Chinese stance strings with English

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -123,11 +123,11 @@ async def websocket_simulation(websocket: WebSocket):
                 # 根据观点值判断立场
                 if agent_opinion is not None:
                     if agent_opinion < -0.3:
-                        stance = "误信"
+                        stance = "misled"
                     elif agent_opinion > 0.3:
-                        stance = "正确认知"
+                        stance = "correct"
                     else:
-                        stance = "中立"
+                        stance = "neutral"
                     progress_data["agent_stance"] = stance
 
             progress_data["message"] = f"正在推演 Agent {step}/{total}" + (f" (ID:{agent_id})" if agent_id is not None else "")


### PR DESCRIPTION
## Summary
- Replace "误信" with "misled"
- Replace "正确认知" with "correct"
- Replace "中立" with "neutral"
- Enables i18n for WebSocket messages

## Problem
WebSocket progress messages used hardcoded Chinese stance strings that prevented frontend internationalization.

## Solution
Use English stance constants that can be translated on the frontend:
```python
if agent_opinion < -0.3:
    stance = "misled"
elif agent_opinion > 0.3:
    stance = "correct"
else:
    stance = "neutral"
```

## Test Plan
- WebSocket messages send English stance values
- Frontend can translate as needed

Fixes #2379

🤖 Generated with [Claude Code](https://claude.com/claude-code)